### PR TITLE
Github archiving fixes

### DIFF
--- a/github-tidy
+++ b/github-tidy
@@ -28,6 +28,9 @@ if [[ ! $PROJECTS ]]; then
 fi
 
 backup_and_delete_repo(){
+    # Exit program on first error
+    set -e
+
     project=$1
 
     # Verify if project exists

--- a/github-tidy
+++ b/github-tidy
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 GITHUB_API=${GITHUB_API:-https://api.github.com}
-GITHUB_CLONE=${GITHUB_REPO:-git@github.com}
+GITHUB_CLONE=${GITHUB_CLONE:-https://$GH_TOKEN@github.com}
 DEFAULT_ORGANIZATION=$1
 S3_BUCKET_BACKUP=$2
 
@@ -41,7 +41,7 @@ backup_and_delete_repo(){
     fi
 
     # Clone and generate a bundle file
-    git clone $GITHUB_CLONE:$DEFAULT_ORGANIZATION/$project.git
+    git clone $GITHUB_CLONE/$DEFAULT_ORGANIZATION/$project.git
     cd $project
     git bundle create $project.bundle --all
     mv $project.bundle ../


### PR DESCRIPTION
## First: Change to exit program when errors:

It could happens things like this:

![image](https://user-images.githubusercontent.com/756802/90174994-2931c700-dd7d-11ea-846c-94a1d9b9f860.png)

## Second: Change to use HTTPS with GH_TOKEN to clone repos

We already use GH_TOKEN to use Github API, it's easy to use it to clone repo before generate bundle.